### PR TITLE
Adds support for SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Extension for EntityFramework for joins to in-memory data. Both Entity Framework 6 and Entity Framework Core are supported!
 Used SQL standard syntax. 
 
-Tested with: MSSQL and PostgreSQL. (others should also work as standard EF API and SQL standard syntax are used)
+Tested with: MSSQL, PostgreSQL, and SQLite. (others should also work as standard EF API and SQL standard syntax are used)
 
 ## Usage
 

--- a/src/EntityFramework.MemoryJoin.sln
+++ b/src/EntityFramework.MemoryJoin.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2009
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29215.179
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFramework.MemoryJoin.TestRunner45", "EntityFramework.MemoryJoin.TestRunner45\EntityFramework.MemoryJoin.TestRunner45.csproj", "{1AD8B2B8-6163-41B8-9D85-C3F8805E8580}"
 EndProject
@@ -16,6 +16,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NuGet", "NuGet", "{B4EAFAEC
 		CreatePackage.bat = CreatePackage.bat
 		Package.nuspec = Package.nuspec
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFrameworkCore.MemoryJoin.IntegrationTests", "EntityFrameworkCore.MemoryJoin.IntegrationTests\EntityFrameworkCore.MemoryJoin.IntegrationTests.csproj", "{3569F701-2F21-4880-BEDB-AC86D96EEC60}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,6 +41,10 @@ Global
 		{26B3DE1A-5E61-4876-9ED0-21F40D149E6D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{26B3DE1A-5E61-4876-9ED0-21F40D149E6D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{26B3DE1A-5E61-4876-9ED0-21F40D149E6D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3569F701-2F21-4880-BEDB-AC86D96EEC60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3569F701-2F21-4880-BEDB-AC86D96EEC60}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3569F701-2F21-4880-BEDB-AC86D96EEC60}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3569F701-2F21-4880-BEDB-AC86D96EEC60}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/EntityFramework.MemoryJoin/Internal/KnownProvider.cs
+++ b/src/EntityFramework.MemoryJoin/Internal/KnownProvider.cs
@@ -6,6 +6,8 @@
 
         Mssql = 1,
 
-        PostgreSql = 2
+        PostgreSql = 2,
+
+        Sqlite = 3,
     }
 }

--- a/src/EntityFrameworkCore.MemoryJoin.IntegrationTests/EntityFrameworkCore.MemoryJoin.IntegrationTests.csproj
+++ b/src/EntityFrameworkCore.MemoryJoin.IntegrationTests/EntityFrameworkCore.MemoryJoin.IntegrationTests.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Utils\" />
+    <Folder Include="TestModels\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EntityFramework.MemoryJoin\EntityFramework.MemoryJoin.csproj" />
+    <ProjectReference Include="..\EntityFrameworkCore.MemoryJoin\EntityFrameworkCore.MemoryJoin.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/EntityFrameworkCore.MemoryJoin.IntegrationTests/SqliteTests.cs
+++ b/src/EntityFrameworkCore.MemoryJoin.IntegrationTests/SqliteTests.cs
@@ -1,0 +1,111 @@
+﻿using EntityFrameworkCore.MemoryJoin.IntegrationTests.TestModels;
+using EntityFrameworkCore.MemoryJoin.IntegrationTests.Utils;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace EntityFrameworkCore.MemoryJoin.IntegrationTests
+{
+	[TestClass]
+	public class SqliteTests
+	{
+		public TestContext TestContext { get; set; }
+
+		[TestMethod]
+		public async Task FromLocalList_ShouldReturnEmptyCollection_WhenJoinSourcesAreBothEmpty()
+		{
+			using (var context = CreateTestDbContext(nameof(FromLocalList_ShouldReturnEmptyCollection_WhenJoinSourcesAreBothEmpty)))
+			{
+				// test with both an empty in-memory collection and an empty real table
+				var emptyCollection = new List<TestInMemoryEntity>(0);
+
+				var inMemoryEntities = context.FromLocalList(emptyCollection);
+
+				var joinedQueryable = context.Entities.Join(
+					inMemoryEntities,
+					inner => inner.Id,
+					outer => outer.Id,
+					(inner, outer) => new { Id = inner.Id, FromRealTable = inner.TestString, FromInMemoryTable = outer.Prop1 });
+
+				var result = await joinedQueryable.ToListAsync();
+				Assert.AreEqual(0, result.Count);
+			}
+		}
+
+		[TestMethod]
+		public async Task FromLocalList_ShouldReturnEmptyCollection_WhenInMemoryEntitiesIsEmpty()
+		{
+			using (var context = CreateTestDbContext(nameof(FromLocalList_ShouldReturnEmptyCollection_WhenInMemoryEntitiesIsEmpty)))
+			{
+				// test with an empty in-memory collection
+				var emptyCollection = new List<TestInMemoryEntity>(0);
+				var inMemoryEntities = context.FromLocalList(emptyCollection);
+
+				// fill up some values in the real table
+				context.AddRange(
+					new TestEntity { Id = "1", TestInt = 1234, TestString = "abc" },
+					new TestEntity { Id = "2", TestInt = 5678, TestString = "def" });
+				await context.SaveChangesAsync();
+
+				var joinedQueryable = context.Entities.Join(
+					inMemoryEntities,
+					inner => inner.Id,
+					outer => outer.Id,
+					(inner, outer) => new { Id = inner.Id, FromRealTable = inner.TestString, FromInMemoryTable = outer.Prop1 });
+
+				var result = await joinedQueryable.ToListAsync();
+				Assert.AreEqual(0, result.Count);
+			}
+		}
+
+		[TestMethod]
+		public async Task FromLocalList_ShouldReturnJoinedCollection_WhenSourcesContainAnIntersection()
+		{
+			using (var context = CreateTestDbContext(nameof(FromLocalList_ShouldReturnEmptyCollection_WhenInMemoryEntitiesIsEmpty)))
+			{
+				// fill up the in-memory table with 1 match
+				var queryData = new List<TestInMemoryEntity> { new TestInMemoryEntity { Id = "1", Prop1 = 999 } };
+				var inMemoryEntities = context.FromLocalList(queryData);
+
+				// fill up some values in the real table
+				context.AddRange(
+					new TestEntity { Id = "1", TestInt = 1234, TestString = "abc" },
+					new TestEntity { Id = "2", TestInt = 5678, TestString = "def" });
+				await context.SaveChangesAsync();
+
+				var joinedQueryable = context.Entities.Join(
+					inMemoryEntities,
+					inner => inner.Id,
+					outer => outer.Id,
+					(inner, outer) => new { Id = inner.Id, FromRealTable = inner.TestString, FromInMemoryTable = outer.Prop1 });
+
+				var result = await joinedQueryable.ToListAsync();
+				Assert.AreEqual(1, result.Count);
+				Assert.AreEqual(new { Id = "1", FromRealTable = "abc", FromInMemoryTable = 999 }, result.First());
+			}
+		}
+
+		private TestDbContext CreateTestDbContext(string databaseName)
+		{
+			var builder = new DbContextOptionsBuilder<TestDbContext>();
+
+			// Create an in-memory DB for test purposes.
+			var connection = new SqliteConnection("Data Source=:memory:;");
+			connection.Open();
+			builder = builder.UseSqlite(connection).EnableSensitiveDataLogging(true);
+
+			if (TestContext != default)
+			{
+				builder.UseLoggerFactory(new TestLoggerFactory(() => TestContext));
+			}
+
+			var context = new TestDbContext(builder.Options);
+			context.Database.EnsureCreated();
+
+			return context;
+		}
+	}
+}

--- a/src/EntityFrameworkCore.MemoryJoin.IntegrationTests/TestModels/TestDbContext.cs
+++ b/src/EntityFrameworkCore.MemoryJoin.IntegrationTests/TestModels/TestDbContext.cs
@@ -1,0 +1,16 @@
+﻿namespace EntityFrameworkCore.MemoryJoin.IntegrationTests.TestModels
+{
+    using Microsoft.EntityFrameworkCore;
+
+    public class TestDbContext : DbContext
+    {
+        public TestDbContext(DbContextOptions<TestDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<TestEntity> Entities { get; set; }
+
+        protected DbSet<QueryModelClass> QueryData { get; set; }
+    }
+}

--- a/src/EntityFrameworkCore.MemoryJoin.IntegrationTests/TestModels/TestEntity.cs
+++ b/src/EntityFrameworkCore.MemoryJoin.IntegrationTests/TestModels/TestEntity.cs
@@ -1,0 +1,11 @@
+﻿namespace EntityFrameworkCore.MemoryJoin.IntegrationTests.TestModels
+{
+    public class TestEntity
+    {
+        public string Id { get; set; }
+
+        public int TestInt { get; set; }
+
+        public string TestString { get; set; }
+    }
+}

--- a/src/EntityFrameworkCore.MemoryJoin.IntegrationTests/TestModels/TestInMemoryEntity.cs
+++ b/src/EntityFrameworkCore.MemoryJoin.IntegrationTests/TestModels/TestInMemoryEntity.cs
@@ -1,0 +1,9 @@
+﻿namespace EntityFrameworkCore.MemoryJoin.IntegrationTests.TestModels
+{
+    public class TestInMemoryEntity
+    {
+        public string Id { get; set; }
+
+        public int Prop1 { get; set; }
+    }
+}

--- a/src/EntityFrameworkCore.MemoryJoin.IntegrationTests/Utils/TestLogger.cs
+++ b/src/EntityFrameworkCore.MemoryJoin.IntegrationTests/Utils/TestLogger.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EntityFrameworkCore.MemoryJoin.IntegrationTests.Utils
+{
+	/// <summary>
+	/// An implementation of <see cref="ILogger"/> that will attach the logs to the test case output.
+	/// </summary>
+	internal class TestLogger : ILogger
+    {
+        private readonly TestContext context;
+
+		public TestLogger(TestContext context) => this.context = context;
+
+        /// <inheritdoc/>
+        public IDisposable BeginScope<TState>(TState state) => StubScope.Instance;
+
+        /// <inheritdoc/>
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        /// <inheritdoc/>
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            try
+            {
+                this.context.WriteLine($"[{logLevel}]: {formatter(state, exception)} (EventId: {eventId})");
+            }
+            catch (InvalidOperationException)
+            {
+                // InvalidOperationExceptions are thrown when no test case is running (e.g. during Dispose()).
+                // As such, if the service is logging something during disposal, we can't log it associated to
+                // the test case.
+            }
+        }
+
+        private class StubScope : IDisposable
+        {
+            public static readonly StubScope Instance = new StubScope();
+
+            public void Dispose()
+            {
+                // Method intentionally left empty.
+            }
+        }
+    }
+}

--- a/src/EntityFrameworkCore.MemoryJoin.IntegrationTests/Utils/TestLoggerFactory.cs
+++ b/src/EntityFrameworkCore.MemoryJoin.IntegrationTests/Utils/TestLoggerFactory.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EntityFrameworkCore.MemoryJoin.IntegrationTests.Utils
+{
+    /// <summary>
+    /// An implementation of <see cref="ILoggerFactory"/> that will produce <see cref="TestLogger"/>s.
+    /// </summary>
+    internal class TestLoggerFactory : ILoggerFactory
+    {
+		private readonly Func<TestContext> testContextFactory;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestLoggerFactory"/> class.
+        /// </summary>
+        /// <param name="testContextFactory">
+        /// A factory for producing <see cref="ITestOutputHelper"/>s. When calling upon this factory,
+        /// it is expected to product a <see cref="ITestOutputHelper"/> for the active test case.
+        /// </param>
+        public TestLoggerFactory(Func<TestContext> testContextFactory) => this.testContextFactory = testContextFactory;
+
+        /// <inheritdoc/>
+        public void AddProvider(ILoggerProvider provider)
+        {
+            // Ignore any providers passed to this factory.
+        }
+
+        /// <inheritdoc/>
+        public ILogger CreateLogger(string categoryName) => new TestLogger(this.testContextFactory());
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            // Intentionally left blank as there are no resources to dispose
+        }
+    }
+}

--- a/src/EntityFrameworkCore.MemoryJoin.TestRunnerCore/EntityFrameworkCore.MemoryJoin.TestRunnerCore.csproj
+++ b/src/EntityFrameworkCore.MemoryJoin.TestRunnerCore/EntityFrameworkCore.MemoryJoin.TestRunnerCore.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.2.4" />
   </ItemGroup>
 

--- a/src/EntityFrameworkCore.MemoryJoin/EntityFrameworkCore.MemoryJoin.csproj
+++ b/src/EntityFrameworkCore.MemoryJoin/EntityFrameworkCore.MemoryJoin.csproj
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
As described in Issue #14, the library is currently not compatible with SQLite. The issue is that SQLite doesn't support column aliasing in the `FROM` clause, you have to instead do it in a `WITH` clause. For example:
```
SELECT * FROM (WITH tempTable(col1, col2, col3) AS (VALUES (1, 2, 3)) SELECT * FROM tempTable)
```

This PR introduces support for SQLite by treating the creation of the in-memory table query differently for SQLite, as per the abovementioned restrictions.

It also adds an integration test project for validation SQL changes, and upgrades to EF Core version 3.1.3 (the latest at the time of writing).

The existing code has been validated using an Azure SQL DB, but not PostgreSQL.