### PR TITLE
Fix .Net 6.0

### DIFF
--- a/src/EntityFramework.MemoryJoin/Properties/AssemblyInfo.cs
+++ b/src/EntityFramework.MemoryJoin/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.7.5.0")]
-[assembly: AssemblyFileVersion("0.7.5.0")]
+[assembly: AssemblyVersion("0.7.7.0")]
+[assembly: AssemblyFileVersion("0.7.7.0")]

--- a/src/EntityFrameworkCore.MemoryJoin.Ef6/EntityFrameworkCore.MemoryJoin.Ef6.csproj
+++ b/src/EntityFrameworkCore.MemoryJoin.Ef6/EntityFrameworkCore.MemoryJoin.Ef6.csproj
@@ -6,9 +6,9 @@
     <Company />
     <Authors>Anton Shkuratov</Authors>
     <PackageId>EntityFramework.MemoryJoin</PackageId>
-    <Version>0.7.5</Version>
-    <AssemblyVersion>0.7.5.0</AssemblyVersion>
-    <FileVersion>0.7.5.0</FileVersion>
+    <Version>0.7.7</Version>
+    <AssemblyVersion>0.7.7.0</AssemblyVersion>
+    <FileVersion>0.7.7.0</FileVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <AssemblyName>EntityFrameworkCore.MemoryJoin</AssemblyName>
   </PropertyGroup>

--- a/src/EntityFrameworkCore.MemoryJoin.IntegrationTests/EntityFrameworkCore.MemoryJoin.IntegrationTests.csproj
+++ b/src/EntityFrameworkCore.MemoryJoin.IntegrationTests/EntityFrameworkCore.MemoryJoin.IntegrationTests.csproj
@@ -1,21 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
   </ItemGroup>
-  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
+  </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkCore.MemoryJoin.TestRunnerCore/EntityFrameworkCore.MemoryJoin.TestRunnerCore.csproj
+++ b/src/EntityFrameworkCore.MemoryJoin.TestRunnerCore/EntityFrameworkCore.MemoryJoin.TestRunnerCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -13,10 +13,15 @@
     <DefineConstants>TRACE;EFCore</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkCore.MemoryJoin/EntityFrameworkCore.MemoryJoin.csproj
+++ b/src/EntityFrameworkCore.MemoryJoin/EntityFrameworkCore.MemoryJoin.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <Copyright>Copyright © Anton Shkuratov 2018</Copyright>
     <Company />
     <Authors>Anton Shkuratov</Authors>
     <PackageId>EntityFramework.MemoryJoin</PackageId>
-    <Version>0.7.5</Version>
-    <AssemblyVersion>0.7.5.0</AssemblyVersion>
-    <FileVersion>0.7.5.0</FileVersion>
+    <Version>0.7.7</Version>
+    <AssemblyVersion>0.7.7.0</AssemblyVersion>
+    <FileVersion>0.7.7.0</FileVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
@@ -28,9 +28,13 @@
     <Compile Include="..\EntityFramework.MemoryJoin\Internal\ValuesInjectionMethodInternal.cs" Link="Internal\ValuesInjectionMethodInternal.cs" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.3" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Solve https://github.com/neisbut/EntityFramework.MemoryJoin/issues/24

.Net 6.0 does not implement any .Net standard => we need a separate build targetting .Net 6.0 specifically with up-to-date EF Core packages