### PR TITLE
Fix .NET 7.0

### DIFF
--- a/src/EntityFramework.MemoryJoin/Properties/AssemblyInfo.cs
+++ b/src/EntityFramework.MemoryJoin/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.7.7.0")]
-[assembly: AssemblyFileVersion("0.7.7.0")]
+[assembly: AssemblyVersion("0.7.8.0")]
+[assembly: AssemblyFileVersion("0.7.8.0")]

--- a/src/EntityFrameworkCore.MemoryJoin.Ef6/EntityFrameworkCore.MemoryJoin.Ef6.csproj
+++ b/src/EntityFrameworkCore.MemoryJoin.Ef6/EntityFrameworkCore.MemoryJoin.Ef6.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
     <Copyright>Copyright © Anton Shkuratov 2018</Copyright>
     <Company />
     <Authors>Anton Shkuratov</Authors>
     <PackageId>EntityFramework.MemoryJoin</PackageId>
-    <Version>0.7.7</Version>
-    <AssemblyVersion>0.7.7.0</AssemblyVersion>
-    <FileVersion>0.7.7.0</FileVersion>
+    <Version>0.7.8</Version>
+    <AssemblyVersion>0.7.8.0</AssemblyVersion>
+    <FileVersion>0.7.8.0</FileVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <AssemblyName>EntityFrameworkCore.MemoryJoin</AssemblyName>
+    <TargetFrameworks>net7.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkCore.MemoryJoin.IntegrationTests/EntityFrameworkCore.MemoryJoin.IntegrationTests.csproj
+++ b/src/EntityFrameworkCore.MemoryJoin.IntegrationTests/EntityFrameworkCore.MemoryJoin.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -11,10 +11,17 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkCore.MemoryJoin.TestRunnerCore/EntityFrameworkCore.MemoryJoin.TestRunnerCore.csproj
+++ b/src/EntityFrameworkCore.MemoryJoin.TestRunnerCore/EntityFrameworkCore.MemoryJoin.TestRunnerCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -18,10 +18,17 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkCore.MemoryJoin/EntityFrameworkCore.MemoryJoin.csproj
+++ b/src/EntityFrameworkCore.MemoryJoin/EntityFrameworkCore.MemoryJoin.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;netstandard2.1</TargetFrameworks>
     <Copyright>Copyright © Anton Shkuratov 2018</Copyright>
     <Company />
     <Authors>Anton Shkuratov</Authors>
     <PackageId>EntityFramework.MemoryJoin</PackageId>
-    <Version>0.8.0</Version>
-    <AssemblyVersion>0.8.0.0</AssemblyVersion>
-    <FileVersion>0.8.0.0</FileVersion>
+    <Version>0.9.0</Version>
+    <AssemblyVersion>0.9.0.0</AssemblyVersion>
+    <FileVersion>0.9.0.0</FileVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
@@ -32,9 +32,14 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.3" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.0" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.0" />
+  </ItemGroup>
 </Project>

--- a/src/EntityFrameworkCore.MemoryJoin/MemoryJoiner.cs
+++ b/src/EntityFrameworkCore.MemoryJoin/MemoryJoiner.cs
@@ -162,7 +162,7 @@ namespace EntityFrameworkCore.MemoryJoin
                 var set = setMethod.MakeGenericMethod(queryClass)
                     .Invoke(context, new object[] { });
 
-                if (fromSqlMethod != null)
+                if (fromSqlMethod != null && rawSqlStringType != null)
                 {
                     // .Net Core < 5 case
                     var rawSqlString = Activator.CreateInstance(rawSqlStringType, new object[] { sb.ToString() });


### PR DESCRIPTION
Hi,

The library has an exception for .NET 7.0. This PR should fix it.

```
System.MissingMethodException: Method not found: 'System.String Microsoft.EntityFrameworkCore.RelationalPropertyExtensions.GetColumnName(Microsoft.EntityFrameworkCore.Metadata.IProperty)'.
   at EntityFramework.MemoryJoin.Internal.EFHelper.GetKeyProperty(DbContext context, Type t)
   at EntityFramework.MemoryJoin.Internal.MappingHelper.GetEntityMapping[T](DbContext context, Type queryClass, Dictionary`2 allowedPropertyMapping)
   at EntityFrameworkCore.MemoryJoin.MemoryJoiner.FromLocalList[T](DbContext context, IList`1 data, Type queryClass, ValuesInjectionMethod method)
   at EntityFrameworkCore.MemoryJoin.MemoryJoiner.FromLocalList[T](DbContext context, IList`1 data, Type queryClass)
   at EntityFrameworkCore.MemoryJoin.MemoryJoiner.FromLocalList[T](DbContext context, IList`1 data)
```